### PR TITLE
Update source code to be compatible with zig 0.15.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -87,16 +87,16 @@ pub const newlib = struct {
 };
 
 pub fn build(b: *std.Build) void {
-    _ = b.addModule("gatz", .{ .root_source_file = b.path("src/gatz.zig") });
-
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
     const exe = b.addExecutable(.{
         .name = "gatz",
-        .root_source_file = b.path("src/gatz.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/gatz.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     const clap = b.dependency("clap", .{});
     exe.root_module.addImport("clap", clap.module("clap"));
@@ -111,9 +111,7 @@ pub fn build(b: *std.Build) void {
     run_step.dependOn(&run_cmd.step);
 
     const tests = b.addTest(.{
-        .root_source_file = b.path("src/gatz.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = exe.root_module,
     });
     tests.root_module.addImport("clap", clap.module("clap"));
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .fingerprint = 0x35239561c4f90a68,
     .dependencies = .{
         .clap = .{
-            .url = "git+https://github.com/Hejsil/zig-clap#e47028deaefc2fb396d3d9e9f7bd776ae0b2a43a",
-            .hash = "clap-0.10.0-oBajB434AQBDh-Ei3YtoKIRxZacVPF1iSwp3IX_ZB8f0",
+            .url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.11.0.tar.gz",
+            .hash = "clap-0.11.0-oBajB-HnAQDPCKYzwF7rO3qDFwRcD39Q0DALlTSz5H7e",
         },
     },
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .gatz,
     .version = "0.0.0",
-    .minimum_zig_version = "0.14.1",
+    .minimum_zig_version = "0.15.1",
     .fingerprint = 0x35239561c4f90a68,
     .dependencies = .{
         .clap = .{

--- a/src/converter.zig
+++ b/src/converter.zig
@@ -290,7 +290,7 @@ test "Valid Conversion" {
         .cpu_features_add = std.Target.arm.featureSet(&[_]std.Target.arm.Feature{std.Target.arm.Feature.fp_armv8d16sp}),
     };
     const my_target: Target = .{ .cpu = gcc.cpu.@"cortex-m7", .instruction_set = .thumb, .float_abi = .hard, .fpu = gcc.fpu.@"fpv5-sp-d16" };
-    try std.testing.expectEqualDeep(some_query, try my_target.toTargetQuery());
+    try std.testing.expectEqual(some_query, try my_target.toTargetQuery());
 }
 
 test "Invalid Conversion" {

--- a/src/converter.zig
+++ b/src/converter.zig
@@ -25,7 +25,6 @@ pub const Target = struct {
     fn toArmFeatureSet(self: Target) ConversionError!std.Target.Cpu.Feature.Set {
 
         // Currently space for 16 features is plenty
-        // var cpu_features = std.BoundedArray(std.Target.arm.Feature, 16).init(0) catch unreachable;
         var features_list: [16]std.Target.arm.Feature = undefined;
         var cpu_features = std.ArrayList(std.Target.arm.Feature).initBuffer(&features_list);
 

--- a/src/converter.zig
+++ b/src/converter.zig
@@ -25,16 +25,18 @@ pub const Target = struct {
     fn toArmFeatureSet(self: Target) ConversionError!std.Target.Cpu.Feature.Set {
 
         // Currently space for 16 features is plenty
-        var cpu_features = std.BoundedArray(std.Target.arm.Feature, 16).init(0) catch unreachable;
+        // var cpu_features = std.BoundedArray(std.Target.arm.Feature, 16).init(0) catch unreachable;
+        var features_list: [16]std.Target.arm.Feature = undefined;
+        var cpu_features = std.ArrayList(std.Target.arm.Feature).initBuffer(&features_list);
 
         if (self.float_abi == .softfp)
-            cpu_features.append(std.Target.arm.Feature.soft_float) catch return ConversionError.FeatureOverflow;
+            cpu_features.appendBounded(std.Target.arm.Feature.soft_float) catch return ConversionError.FeatureOverflow;
 
         if (self.fpu) |fpu| {
-            cpu_features.appendSlice(fpu.zig_features) catch return ConversionError.FeatureOverflow;
+            cpu_features.appendSliceBounded(fpu.zig_features) catch return ConversionError.FeatureOverflow;
         }
 
-        return std.Target.arm.featureSet(cpu_features.slice());
+        return std.Target.arm.featureSet(cpu_features.items);
     }
 
     fn validateFpuSettings(self: Target) ConversionError!void {

--- a/src/gatz.zig
+++ b/src/gatz.zig
@@ -18,8 +18,10 @@ test "gatz" {
 }
 
 fn showHelp() anyerror!void {
-    var stdout_buffered = std.io.bufferedWriter(std.io.getStdOut().writer());
-    const stdout = stdout_buffered.writer();
+    var stdout_buffer: [1024]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    const stdout = &stdout_writer.interface;
+
     try stdout.writeAll("Usage: ");
     try stdout.writeAll(program_name);
     try stdout.writeAll(
@@ -28,7 +30,7 @@ fn showHelp() anyerror!void {
     );
     for (sub_commands) |sub_command|
         try sub_command.help(stdout);
-    try stdout_buffered.flush();
+    try stdout.flush();
 }
 
 /// Check that the Zig target is supported by gatz
@@ -112,18 +114,22 @@ const SubCommand = struct {
     }
 
     fn usageOut(sub_command: SubCommand, p: []const clap.Param(clap.Help)) !void {
-        var stdout_buffered = std.io.bufferedWriter(std.io.getStdOut().writer());
-        try sub_command.usage(stdout_buffered.writer(), p);
-        try stdout_buffered.flush();
+        var stdout_buffer: [1024]u8 = undefined;
+        var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+        const stdout = &stdout_writer.interface;
+        try sub_command.usage(stdout, p);
+        try stdout.flush();
     }
 
     fn usageErr(sub_command: SubCommand, p: []const clap.Param(clap.Help), prepend_msg: []const u8) !void {
-        var stderr_buffered = std.io.bufferedWriter(std.io.getStdErr().writer());
+        var stderr_buffer: [1024]u8 = undefined;
+        var stderr_writer = std.fs.File.stderr().writer(&stderr_buffer);
+        const stderr = &stderr_writer.interface;
         if (prepend_msg.len > 0) {
-            _ = try stderr_buffered.write(prepend_msg);
+            _ = try stderr.write(prepend_msg);
         }
-        try sub_command.usage(stderr_buffered.writer(), p);
-        try stderr_buffered.flush();
+        try sub_command.usage(stderr, p);
+        try stderr.flush();
     }
 
     fn usage(sub_command: SubCommand, stream: anytype, p: []const clap.Param(clap.Help)) !void {
@@ -146,6 +152,10 @@ fn cmdTranslate(
     allocator: std.mem.Allocator,
     args_iter: *std.process.ArgIterator,
 ) anyerror!void {
+    var stderr_buffer: [1024]u8 = undefined;
+    var stderr_writer = std.fs.File.stderr().writer(&stderr_buffer);
+    const stderr = &stderr_writer.interface;
+
     const params = comptime clap.parseParamsComptime(
         \\-h, --help              Display this help and exit.
         \\--mcpu <str>            GCC cpu target flag         (Required)
@@ -161,7 +171,7 @@ fn cmdTranslate(
         .diagnostic = &diag,
         .allocator = allocator,
     }) catch |err| {
-        diag.report(std.io.getStdErr().writer(), err) catch {};
+        diag.report(stderr, err) catch {};
         return err;
     };
     defer parsed.deinit();
@@ -169,25 +179,23 @@ fn cmdTranslate(
     if (parsed.args.help != 0)
         return sub_command.usageOut(&params);
 
-    var stderr_buffered = std.io.bufferedWriter(std.io.getStdErr().writer());
-    const stderr = stderr_buffered.writer();
     const FlagTranslationError = errors.FlagTranslationError;
     const target = Target.fromFlags(parsed.args.mcpu, parsed.args.@"mfloat-abi", parsed.args.mfpu, parsed.args.mthumb > 0, parsed.args.marm > 0) catch |err| switch (err) {
         FlagTranslationError.MissingCpu => return sub_command.usageErr(&params, "--mcpu argument required\n"),
         FlagTranslationError.InvalidCpu => {
             try stderr.print("--mcpu={?s} is not a valid CPU, see info command for valid CPUs\n", .{parsed.args.mcpu});
-            try stderr_buffered.flush();
+            try stderr.flush();
             return;
         },
         FlagTranslationError.InvalidFloatAbi => {
             try stderr.print("--mfloat-abi={?s} is not a valid float abi, valid options are \"hard\", \"softfp\", and \"soft\"\n", .{parsed.args.@"mfloat-abi"});
-            try stderr_buffered.flush();
+            try stderr.flush();
             return;
         },
         FlagTranslationError.MissingFpu => return sub_command.usageErr(&params, "--mfpu is required if --mfloat-abi!=soft\n"),
         FlagTranslationError.InvalidFpu => {
             try stderr.print("--mfpu={?s} is not a valid FPU, see info command for valid FPUs\n", .{parsed.args.mfpu});
-            try stderr_buffered.flush();
+            try stderr.flush();
             return;
         },
     };
@@ -198,10 +206,11 @@ fn cmdTranslate(
     const zig_cpu_str = try query.serializeCpuAlloc(allocator);
     defer allocator.free(zig_cpu_str);
 
-    var stdout_buffered = std.io.bufferedWriter(std.io.getStdOut().writer());
-    const stdout = stdout_buffered.writer();
+    var stdout_buffer: [1024]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    const stdout = &stdout_writer.interface;
     try stdout.print("Translated `zig build` options: -Dtarget={s} -Dcpu={s}\n", .{ zig_triple, zig_cpu_str });
-    try stdout_buffered.flush();
+    try stdout.flush();
 }
 
 fn cmdInfo(
@@ -215,12 +224,16 @@ fn cmdInfo(
         \\
     );
 
+    var stderr_buffer: [1024]u8 = undefined;
+    var stderr_writer = std.fs.File.stderr().writer(&stderr_buffer);
+    const stderr = &stderr_writer.interface;
+
     var diag = clap.Diagnostic{};
     var parsed = clap.parseEx(clap.Help, &params, clap.parsers.default, args_iter, .{
         .diagnostic = &diag,
         .allocator = allocator,
     }) catch |err| {
-        diag.report(std.io.getStdErr().writer(), err) catch {};
+        diag.report(stderr, err) catch {};
         return err;
     };
     defer parsed.deinit();
@@ -228,16 +241,15 @@ fn cmdInfo(
     if (parsed.args.help != 0)
         return sub_command.usageOut(&params);
 
-    var stderr_buffered = std.io.bufferedWriter(std.io.getStdErr().writer());
-    const stderr = stderr_buffered.writer();
     const cpu_maybe: ?Cpu = if (parsed.args.mcpu) |mcpu_str| Cpu.fromString(mcpu_str) catch {
         try stderr.print("--mcpu={?s} is not a valid CPU, see info command for valid CPUs\n", .{parsed.args.mcpu});
-        try stderr_buffered.flush();
+        try stderr.flush();
         return;
     } else null;
 
-    var stdout_buffered = std.io.bufferedWriter(std.io.getStdOut().writer());
-    const stdout = stdout_buffered.writer();
+    var stdout_buffer: [1024]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    const stdout = &stdout_writer.interface;
 
     if (cpu_maybe) |cpu_val| {
         try cpu_val.printInfo(stdout);
@@ -246,7 +258,7 @@ fn cmdInfo(
             try @field(cpu, decl.name).printInfo(stdout);
         }
     }
-    try stdout_buffered.flush();
+    try stdout.flush();
 }
 
 const sub_commands = [_]SubCommand{


### PR DESCRIPTION
I've update build script and source code to be compliant with zig 0.15.1.

For build script I simply updated module struct members and for source code:
 - I replaced `BoundedArray` by `ArrayList` in src/converter.zig
 - I updated stdout & stderr in src/gatz.zig
 
To pass the test, I replaced `expectEqualDeep` by `expectEqual` from converter.zig: `test "Valid Conversion"`. It seem there is a bug in std lib. I tracked it until `std.Target.OsVersion` but I wasn't able to find it. I havn't open ticket on zig repo because I can't reproduce it on zig main branch.

-----
PS: I'm zig beginner, maybe this implementation isn't optimal.